### PR TITLE
report downloaded ciphertexts size and minor changes

### DIFF
--- a/harness/run_submission.py
+++ b/harness/run_submission.py
@@ -111,7 +111,7 @@ def main():
     utils.log_step(4, "Dataset encoding and encryption")
 
     # Report size of encrypted data
-    utils.log_size(io_dir / "encrypted", "Encrypted database")
+    utils.log_size(io_dir / "ciphertexts_upload", "Encrypted database")
 
     # 4.1 Communication: Upload encrypted database
     if remote_be:
@@ -143,12 +143,12 @@ def main():
         # 8. Client-side: Encrypt the query
         utils.run_exe_or_python(exec_dir, "client_encode_encrypt_query", *this_query_args)
         utils.log_step(8, "Query encryption")
-        utils.log_size(io_dir / "encrypted" / "query.bin" , "Encrypted query")
+        utils.log_size(io_dir / "ciphertexts_upload" / "query.bin" , "Encrypted query")
 
         # 9. Server-side: run server_encrypted_compute
         utils.run_exe_or_python(exec_dir, "server_encrypted_compute", *this_query_args)
         utils.log_step(9, "Encrypted computation")
-
+        utils.log_size(io_dir / "ciphertexts_download" / "results.bin" , "Encrypted results")
 
         # 10. Client-side: decrypt and postprocess
         utils.run_exe_or_python(exec_dir, "client_decrypt_decode", *this_query_args)

--- a/harness/utils.py
+++ b/harness/utils.py
@@ -41,7 +41,7 @@ def build_submission(script_dir: Path, remote_be: bool):
     Build the submission, including pulling dependencies as neeed
     """
     if remote_be:
-        subprocess.run(["pip", "install", "-r", "./submission_remote/requirements.txt"], check=True)
+        subprocess.run([sys.executable, "-m", "pip", "install", "-r", "./submission_remote/requirements.txt"], check=True)
     else:
         # Clone and build OpenFHE if needed
         subprocess.run([script_dir/"get_openfhe.sh"], check=True)
@@ -153,7 +153,7 @@ def run_exe_or_python(base, file_name, *args, check=True):
 
     if py.exists():
         env["PYTHONPATH"] = "."
-        cmd = ["python3", py, *args]
+        cmd = [sys.executable, py, *args]
     elif exe.exists():
         cmd = [exe, *args]
     else:

--- a/measurements/count_small/results-1.json
+++ b/measurements/count_small/results-1.json
@@ -15,7 +15,8 @@
   "Bandwidth": {
     "Public and evaluation keys": "2.6G",
     "Encrypted database": "5.6G",
-    "Encrypted query": "24.0M"
+    "Encrypted query": "24.0M",
+    "Encrypted results": "2.0M"
   },
   "Server Reported": {
     "Encrypted computation": "48s",

--- a/measurements/count_small/results-2.json
+++ b/measurements/count_small/results-2.json
@@ -15,7 +15,8 @@
   "Bandwidth": {
     "Public and evaluation keys": "2.6G",
     "Encrypted database": "5.6G",
-    "Encrypted query": "24.0M"
+    "Encrypted query": "24.0M",
+    "Encrypted results": "2.0M"
   },
   "Server Reported": {
     "Encrypted computation": "49s",

--- a/measurements/count_small/results-3.json
+++ b/measurements/count_small/results-3.json
@@ -15,7 +15,8 @@
   "Bandwidth": {
     "Public and evaluation keys": "2.6G",
     "Encrypted database": "5.6G",
-    "Encrypted query": "24.0M"
+    "Encrypted query": "24.0M",
+    "Encrypted results": "2.0M"
   },
   "Server Reported": {
     "Encrypted computation": "48s",

--- a/measurements/small/results-1.json
+++ b/measurements/small/results-1.json
@@ -15,7 +15,8 @@
   "Bandwidth": {
     "Public and evaluation keys": "2.4G",
     "Encrypted database": "5.6G",
-    "Encrypted query": "24.0M"
+    "Encrypted query": "24.0M",
+    "Encrypted results": "2.0M"
   },
   "Server Reported": {
     "Encrypted computation": "71s",

--- a/measurements/small/results-2.json
+++ b/measurements/small/results-2.json
@@ -15,7 +15,8 @@
   "Bandwidth": {
     "Public and evaluation keys": "2.4G",
     "Encrypted database": "5.6G",
-    "Encrypted query": "24.0M"
+    "Encrypted query": "24.0M",
+    "Encrypted results": "2.0M"
   },
   "Server Reported": {
     "Encrypted computation": "71s",

--- a/measurements/small/results-3.json
+++ b/measurements/small/results-3.json
@@ -15,7 +15,8 @@
   "Bandwidth": {
     "Public and evaluation keys": "2.4G",
     "Encrypted database": "5.6G",
-    "Encrypted query": "24.0M"
+    "Encrypted query": "24.0M",
+    "Encrypted results": "2.0M"
   },
   "Server Reported": {
     "Encrypted computation": "71s",

--- a/submission/include/params.h
+++ b/submission/include/params.h
@@ -129,7 +129,8 @@ public:
     //  ├─io/         # Directory to hold the I/O between client & server parts
     //    ├─ toy/       # The reference implementation has subdirectories
     //       ├─ keys/       # holds the keys
-    //       └─ encrypted/  # holds the ciphertexts (split into subdirectories)
+    //       ├─ ciphertexts_upload/  # holds the ciphertexts to be uploaded to the server
+    //       └─ ciphertexts_download/  # holds the ciphertexts to be downloaded from the server    
     //    ├─ small/
     //       …
     //    ├─ medium/
@@ -140,7 +141,8 @@ public:
     fs::path rtdir() const  { return rootdir; }
     fs::path iodir() const  { return rootdir/"io"/instance_name(size); }
     fs::path keydir() const { return iodir() / "keys"; }
-    fs::path encdir() const { return iodir() / "encrypted"; }
+    fs::path updir() const { return iodir() / "ciphertexts_upload"; }
+    fs::path downdir() const { return iodir() / "ciphertexts_download"; }
     fs::path datadir() const { 
         return rootdir/"datasets"/instance_name(size);
     }

--- a/submission/src/client_decrypt_decode.cpp
+++ b/submission/src/client_decrypt_decode.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
 
   // Read the encrypted answer from disk
   Ciphertext<DCRTPoly> eres;
-  auto res_file = prms.encdir()/"results.bin";
+  auto res_file = prms.downdir()/"results.bin";
   if (!Serial::DeserializeFromFile(res_file, eres, SerType::BINARY)) {
     throw std::runtime_error("failed to read answer from "+res_file.string());
   }

--- a/submission/src/client_encode_encrypt_db.cpp
+++ b/submission/src/client_encode_encrypt_db.cpp
@@ -75,7 +75,7 @@ int main(int argc, char* argv[]) {
   for (int i = 0; i < prms.getNCtxts(); i++) {  // go over the batches
     std::stringstream ssi;
     ssi << std::setw(4) << std::setfill('0') << i;
-    auto dir = prms.encdir() / ("batch" + ssi.str());
+    auto dir = prms.updir() / ("batch" + ssi.str());
     // Create the batch directory and any parent directory as needed
     std::filesystem::create_directories(dir);
 

--- a/submission/src/client_encode_encrypt_query.cpp
+++ b/submission/src/client_encode_encrypt_query.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
   }
   auto pt = cc->MakeCKKSPackedPlaintext(slots);
   auto eqry = cc->Encrypt(pk, pt);  // the encrypted query vector at top level
-  auto q_file = prms.encdir()/"query.bin";
+  auto q_file = prms.updir()/"query.bin";
   if (!Serial::SerializeToFile(q_file, eqry, SerType::BINARY)) {
       throw std::runtime_error("failed to write query to "+q_file.string());
   }

--- a/submission/src/server_encrypted_compute.cpp
+++ b/submission/src/server_encrypted_compute.cpp
@@ -111,6 +111,7 @@ int main(int argc, char* argv[]) {
   constexpr double threshold = 0.8;
   auto timing_fname = prms.iodir()/"server_reported_steps.json";
   auto start_server = std::chrono::system_clock::now();
+  std::filesystem::create_directories(prms.downdir());
 
   // Read the crypto context and the public key from disk
   CryptoContext<DCRTPoly> cc;
@@ -142,7 +143,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Read the query vector from disk
-  auto q_fname = prms.encdir()/"query.bin";
+  auto q_fname = prms.updir()/"query.bin";
   Ciphertext<DCRTPoly> eqry;
   if (!Serial::DeserializeFromFile(q_fname,eqry,SerType::BINARY)){
     throw std::runtime_error(
@@ -153,8 +154,8 @@ int main(int argc, char* argv[]) {
   auto start_computing = std::chrono::system_clock::now();
 
   // Matrix-vector multiplication, reading the encrypted matrix one
-  // ciphertexe at a time from encdir
-  auto result = mat_vec_mult(prms.encdir(), eqry, prms);
+  // ciphertexe at a time from updir
+  auto result = mat_vec_mult(prms.updir(), eqry, prms);
   log_step(1, "Matrix-vector product");
 
   // Compare each slot in the results ctxts to the threshold, using a
@@ -191,7 +192,7 @@ int main(int argc, char* argv[]) {
       now - start_server).count();
     store_server_time(timing_fname, comp_s, total_s);
 
-    std::string out_fname = prms.encdir()/"results.bin";
+    std::string out_fname = prms.downdir()/"results.bin";
     if (!Serial::SerializeToFile(out_fname, result[0], SerType::BINARY)) {
       throw std::runtime_error("Failed to write ciphertext to " + out_fname);
     }
@@ -285,7 +286,7 @@ int main(int argc, char* argv[]) {
       // per column, then rotate by j*N_COLS to put that value in the next
       // available slot in its column.
       for (size_t k = 0; k < indicator.size(); k++) {
-        auto payload_part = get_encrypted_payload(prms.encdir(), k, j);
+        auto payload_part = get_encrypted_payload(prms.updir(), k, j);
         // jth row in the k'th matrix
 
         payload_part = cc->EvalMult(payload_part, indicator[k]);
@@ -346,7 +347,7 @@ int main(int argc, char* argv[]) {
   store_server_time(timing_fname, comp_s, total_s);
 
   // Store the accumulated result back to disk
-  std::string out_fname = prms.encdir()/"results.bin";
+  std::string out_fname = prms.downdir()/"results.bin";
   if (!Serial::SerializeToFile(out_fname, accumulator, SerType::BINARY)) {
     throw std::runtime_error("Failed to write ciphertext to " + out_fname);
   }
@@ -384,7 +385,7 @@ std::vector<Ciphertext<DCRTPoly>> mat_vec_mult(fs::path encdir,
       std::stringstream ssj;
       ssj << std::setw(4) << std::setfill('0') << j;
 
-      auto ct_fname = prms.encdir() / 
+      auto ct_fname = encdir /
           ("batch" + ssj.str()) / ("row_" + ssi.str() + ".bin");
       Ciphertext<DCRTPoly> ct = get_ctxt(ct_fname);
       ct = cc->EvalMultNoRelin(ct, ct_i);

--- a/submission_remote/src/client_decrypt_decode.py
+++ b/submission_remote/src/client_decrypt_decode.py
@@ -8,7 +8,7 @@ import submission_utils
 
 local_file_paths, _ = submission_utils.init(sys.argv)
 
-ct_res     = pickle.load(open(local_file_paths.get_ct_download_path("query"), "rb"))
+ct_res     = pickle.load(open(local_file_paths.get_ct_download_path("results"), "rb"))
 context    = pickle.load(open(local_file_paths.PATH_CONTEXT, "rb"))
 secret_key = pickle.load(open(local_file_paths.PATH_SK, "rb"))
 

--- a/submission_remote/src/server_encrypted_compute.py
+++ b/submission_remote/src/server_encrypted_compute.py
@@ -16,7 +16,7 @@ client = submission_utils.get_lattica_client(local_file_paths)
 ct_res = client.worker_api.apply_hom_pipeline(ct, block_index=1, return_new_state=True)
 
 # Save encrypted result
-pickle.dump(ct_res, open(local_file_paths.get_ct_download_path("query"), "wb"))
+pickle.dump(ct_res, open(local_file_paths.get_ct_download_path("results"), "wb"))
 
 # Parse and save server timing report
 server_timing = client.worker_api.get_last_timing()

--- a/submission_remote/src/submission_utils.py
+++ b/submission_remote/src/submission_utils.py
@@ -47,7 +47,7 @@ class LocalFilePaths:
         self.PATH_ACCESS_TOKEN      = IO_DIR / "access_token.pkl"
         self.PATH_SK                = IO_DIR / "sk.pkl"
         self.PK_DIR                 = IO_DIR / "keys"
-        self.CT_UPLOAD_DIR          = IO_DIR / "encrypted"
+        self.CT_UPLOAD_DIR          = IO_DIR / "ciphertexts_upload"
         self.CT_DOWNLOAD_DIR        = IO_DIR / "ciphertexts_download"
         self.PATH_RAW_RESULT        = IO_DIR / "raw_result.pkl"
         self.PREDICTIONS_PATH       = IO_DIR / "results.bin"


### PR DESCRIPTION
- The harness now reports the results.bin size. 
- Aligned the location of the uploaded and downloaded ciphertexts between the submission, submission_remote, and other benchmarking workloads harnesses.
- Updated the run_exe_or_python to use the virtual environment python version.

I updated the measurements for the small size but I need a larger machine to run the medium size. @shaih can you update those?

Closes #7.